### PR TITLE
feat: Add --no-cache option when pulling images

### DIFF
--- a/crpy/cmd.py
+++ b/crpy/cmd.py
@@ -23,7 +23,7 @@ async def _pull(args):
     if not filename:
         # make file name compatible
         filename = ri.repository.replace(":", "_").replace("/", "_")
-    await ri.pull(filename, args.architecture[0] if args.architecture else None)
+    await ri.pull(filename, args.architecture[0] if args.architecture else None, not args.no_cache)
 
 
 async def _push(args):
@@ -172,6 +172,12 @@ def main(*args):
         nargs=1,
         help="Architecture for the to be pulled.",
         default=None,
+    )
+    pull.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="If should not use the cache when pulling the image.",
+        default=False,
     )
     pull.add_argument("url", nargs=1, help="Remote repository to pull from.")
     pull.add_argument("filename", nargs="?", help="Output file for the compressed image.")

--- a/crpy/registry.py
+++ b/crpy/registry.py
@@ -362,7 +362,10 @@ class RegistryInfo:
             return file_obj.getvalue()
 
     async def pull(
-        self, output_file: Union[str, pathlib.Path, io.BytesIO], architecture: Union[str, Platform, None] = None
+        self,
+        output_file: Union[str, pathlib.Path, io.BytesIO],
+        architecture: Union[str, Platform, None] = None,
+        use_cache: bool = True,
     ):
         """
         Pulls an image from a remote repository. The image will be packed into a tar-file and saved to disk (or to a
@@ -372,6 +375,7 @@ class RegistryInfo:
         :param output_file: path or file-like object to save the binary data.
         :param architecture: architecture to pull the image. If not set, the default registry architecture will be
             used.
+        :param use_cache: enables the local cache, saving layers to ~/.crpy/ folder.
         :return:
         """
         print(f"{self.tag}: Pulling from {self.registry}/{self.repository}")
@@ -382,7 +386,7 @@ class RegistryInfo:
         for layer in await self.get_layers(architecture):
             layer_without_prefix = layer.split(":")[1]
             image.layers.append(
-                Blob.from_any(await self.pull_layer(layer, use_cache=True), digest=layer_without_prefix)
+                Blob.from_any(await self.pull_layer(layer, use_cache=use_cache), digest=layer_without_prefix)
             )
             print(f"{layer_without_prefix[0:12]}: Pull complete")
         image.to_disk(output_file, tags=[str(self)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ authors = [
 ]
 requires-python = ">=3.9.0"
 dependencies = [
-    "requests>=2",
     "async-lru>=2",
     "aiohttp>=3",
     "async-lru>=2",


### PR DESCRIPTION
Forces all layers to be pulled regardless of them being already cached in the file system.

Also prevents the layer from being saved into cache when pulling the image (for CI jobs, for example).